### PR TITLE
Create systemd user dir before creating unit file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo chown root:root "/usr/local/bin/openrgb-load-profile" && sudo chmod 755 "/u
 
 Now, we need to create a `systemd` service (unit file), which will load our OpenRGB script at first login.
 ```bash
-tee "~/.config/systemd/user/openrgb.service" <<EOF
+mkdir -p ~/.config/systemd/user/ && tee "~/.config/systemd/user/openrgb.service" <<EOF
 [Unit]
 Description=Open source RGB lighting control that doesn't depend on manufacturer software.
 After=graphical.target


### PR DESCRIPTION
This patch does what I mentioned in [my issue](https://github.com/gerelef/openrgb-profile-at-startup/issues/2) (#2) and should get this guide working on more distros that don't necessarily have the `~/.config/systemd/user/` directory present by default.