### PR TITLE
Fix issue where tee didn't create file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo chown root:root "/usr/local/bin/openrgb-load-profile" && sudo chmod 755 "/u
 
 Now, we need to create a `systemd` service (unit file), which will load our OpenRGB script at first login.
 ```bash
-mkdir -p ~/.config/systemd/user/ && tee "~/.config/systemd/user/openrgb.service" <<EOF
+mkdir -p ~/.config/systemd/user/ && tee ~/.config/systemd/user/openrgb.service <<EOF
 [Unit]
 Description=Open source RGB lighting control that doesn't depend on manufacturer software.
 After=graphical.target


### PR DESCRIPTION
After a reinstall because of a desktop environment change I refollowed the guide and encountered the issue that tee just returned "Couldn't find openrgb.service". Removing the quotes resolved this issue.